### PR TITLE
Git push releases with Dokku + updated Wikipedia title regex

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'sinatra', '1.4.7'
+gem 'json', '2.0.2'
+gem 'net', '0.3.3'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,36 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.0.4)
+    i18n (0.7.0)
+    json (2.0.2)
+    minitest (5.10.1)
+    net (0.3.3)
+      activesupport
+    rack (1.6.5)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    thread_safe (0.3.5)
+    tilt (2.0.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json (= 2.0.2)
+  net (= 0.3.3)
+  sinatra (= 1.4.7)
+
+BUNDLED WITH
+   1.13.7

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: ruby server.rb

--- a/server.rb
+++ b/server.rb
@@ -12,8 +12,9 @@ helpers do
 
   def wikilinks uri
     html = Net::HTTP.get(uri)
+    STDERR.puts html.inspect
     html.force_encoding('UTF-8')
-    title = (/<title>(.+) - Wikipedia, the free encyclopedia<\/title>/.match html)[1]
+    title = (/<title>(.+) - Wikipedia<\/title>/.match html)[1]
     source = {:url => uri.to_s, :transport => 'http://localhost:4020/proxy'}
     page title, source do
       paragraph "From [[Explore Transport Proxy]]. See [#{uri} wikipedia]"


### PR DESCRIPTION
The attached commits introduce an environment for *automagically* building a Docker container based on this repository with the help of `herokuish` in Dokku, as well as an update to the scraper logic.

This is now live on http://transport-proxy.apps.allmende.io and serves its purpose well at http://jon.fed.wiki/view/welcome-visitors/view/notebook/view/2017/view/wikipedia-articles/